### PR TITLE
added a 18.3 Tarball

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # Labkey version information used by docker-compose.yml and labkey Dockerfile ARGS
-LABKEY_VERSION=18.2
-LABKEY_REVISION=60106
+LABKEY_VERSION=18.3
+LABKEY_REVISION=61806
 LABKEY_DISTRIBUTION=community
-LABKEY_TARBALL=http://labkey.s3.amazonaws.com/downloads/general/r/18.2/LabKey18.2-60106.64-community-bin.tar.gz
+LABKEY_TARBALL=http://labkey.s3.amazonaws.com/downloads/general/r/18.3/LabKey18.3.0-61806.763-community-bin.tar.gz
 
 # Labkey runtime propeties (see https://www.labkey.org/Documentation/wiki-page.view?name=cpasxml#encrypt)
 LABKEY_DB_NAME=labkey

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OSX: https://docs.docker.com/docker-for-mac/
 
 
 # Change Log:
-- updated .env file to use the 18.3 Community Edition tarball from 18.2
+- 2019-01-17 -- updated .env file to use the 18.3 Community Edition tarball from 18.2
 
 
 # Edit .env

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Windows 10: https://docs.docker.com/docker-for-windows/
 OSX: https://docs.docker.com/docker-for-mac/
 
 
+# Change Log:
+- updated .env file to use the 18.3 Community Edition tarball from 18.2
+
+
 # Edit .env
 change the `LABKEY_` prefixed runtime environment variables
 


### PR DESCRIPTION
Hi,

Labkey has updated to 18.3 and thus update the tarball url for the community edition. Did some basic "will it load" testing and seems to work well.

Thanks,

Mike